### PR TITLE
update submodule before installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Now, the redis commands were supported by Pedis as follow:
 ## Getting started
 
 * ```git clone git@github.com:fastio/pedis.git```
-* ```sudo ./install-dependencies.sh```
 * ``` git submodule update --init --recursive```
+* ```sudo ./install-dependencies.sh```
 * ```./configure.py --mode=release --with=pedis```
 * ```ninja-build -j16``` # Assuming 16 system threads.
 * ```build/release/pedis --max-io-requests 1024 --smp 2```


### PR DESCRIPTION
Error in practicing in a clean env:
-  bash: seastar/install-dependencies.sh: No such file or directory

We can't assume seastar always exists.